### PR TITLE
Move PROJECT_GOVERANANCE.md to .github-repo

### DIFF
--- a/PROJECT_GOVERNANCE.md
+++ b/PROJECT_GOVERNANCE.md
@@ -1,0 +1,56 @@
+<!--
+SPDX-FileCopyrightText: 2017-2021 Contributors to the OpenSTF project <korte.termijn.prognoses@alliander.com>
+
+SPDX-License-Identifier: MPL-2.0
+-->
+
+# Project Governance
+
+The basic principle is that decisions are based on consensus. If this decision making process takes too long or a decision is required, the Technical Steering committee has the authority to make a decision.
+
+## Technical Steering Committee
+
+The Technical Steering Committee (TSC) is responsible for:
+
+1. General ambitions, objectives and goals of this project
+1. Guidelines and procedures and tool selection
+1. Architectural and (development) infrastructure choices
+1. Raise subjects/issues that are important for the direction/development of this project
+
+The community council consists of the following members:
+1. Frank Kreuwel
+1. Jan Maarten van Doorn
+2. Jonas van den Bogaard
+3. David Swinkels
+4. Frederik Stoel
+
+Frank Kreuwel will chair the TSC.
+
+Any community member or Contributor can ask that something be reviewed by the TSC by contacting the TSC at korte.termijn.prognoses@alliander.com.
+
+## Maintainers
+
+Maintainers are responsible for maintaining parts of the code-base. Maintainers have the following responsibilities
+
+1. Coordinate development activity
+1. Make sure code/documentation reviews are being done
+1. Coordinate pull-requests
+1. Coordinate bug follow-ups
+1. Coordinate questions
+1. In case of long discussions or arguments, maintainers or other can request a community council decision.
+
+The current maintainers of this project are:
+1. Frank Kreuwel
+2. Jan Maarten van Doorn
+3. David Swinkels
+4. Frederik Stoel
+
+Any community member or Contributor can ask a question or raise a issue to the maintainers by logging a GitHub issue.
+
+## Contributors
+
+Contributors include anyone in the technical community that contributes code, documentation, or other technical artifacts to the project.
+
+Anyone can become a contributor. There is no expectation of commitment to the project, no specific skill requirements and no selection process. To become a contributor, a community member simply has to perform one or more actions that are beneficial to the project.
+
+


### PR DESCRIPTION
Instead of a PROJECT_GOVERNANCE.md file in each repo, I suggest the PROJECT_GOVERNANCE.md file to be added to .github with the other open source community files.

Signed-off-by: Jonas van den Bogaard <3628277+Jonasvdbo@users.noreply.github.com>