### PR TITLE
Fix Profile/readme.md - Add link to LF Energy Slack onboarding instructions

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -21,7 +21,7 @@ OpenSTEF provides automated machine learning pipelines to deliver accurate and e
 - [Dashboard documentation](https://raw.githack.com/OpenSTEF/.github/main/profile/html/openstef_dashboard_doc.html);
 - [Linux Foundation project page](https://openstef.github.io/openstef/index.html);
 - [Video about OpenSTEF](https://www.lfenergy.org/forecasting-to-create-a-more-resilient-optimized-grid/);
-- [OpenSTEF Slack channel](https://app.slack.com/huddle/TLU68MTML/C04P56MSM40). 
+- [LF Energy OpenSTEF Slack channel](https://app.slack.com/huddle/TLU68MTML/C04P56MSM40) ([Instructions to join the LF Energy Slack](https://tac.lfenergy.org/tools/slack.html)) 
 
 
 ## Description


### PR DESCRIPTION
This PR adds a link to the official LF Energy documentation explaining how to join the LF Energy Slack workspace.

The goal is to make it easier for new contributors and community members to find the correct onboarding instructions when they want to join the OpenSTEF Slack channels, and to avoid confusion around account setup.

Official instructions: https://tac.lfenergy.org/tools/slack.html 