### PR TITLE
docs: add AI-assisted contributions guideline to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,6 +160,43 @@ reuse annotate \
 
 All patches and contributions, including those by project members, require review by one of the maintainers. We use GitHub pull requests for this purpose. Consult the [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more information on pull requests.
 
+## AI‑Assisted Contributions 
+AI tools (e.g. LLMs or coding assistants) can be helpful when contributing to OpenSTEF. We welcome their use, as long as contributions remain clear, maintainable, and aligned with the following guidelines.
+
+### General expectations
+- You remain fully responsible for your contribution, regardless of AI usage  
+- You should understand and be able to explain the code you submit  
+- Treat AI as a support tool, not as an autonomous contributor  
+
+### Transparency
+- If AI played a significant role, please disclose this in your pull request or commit message   (e.g. `Assisted-by: <tool name>`)  
+- Minor uses (e.g. fixing grammar or formatting) do not need to be mentioned  
+
+### Quality standards
+AI-assisted contributions must meet the same standards as any other contribution:
+
+- Include tests where applicable  
+- Update documentation if needed  
+- Follow coding style and project conventions (`poe all`)  
+- Clearly describe the problem and your approach  
+
+Please make sure to review and validate all generated code. AI tools can produce incorrect, outdated, or insecure patterns.
+
+### Scope and collaboration
+- Prefer small, well-scoped pull requests that are easy to review  
+- Engage with maintainers via issues if your change is substantial  
+- Avoid submitting large or bulk-generated changes without prior discussion, as they may be rejected.
+
+### Security and licensing
+- Review generated code for potential vulnerabilities  
+- Ensure compliance with project licensing and proper attribution of reused content  
+
+### AI agents
+Autonomous agents or bots are not typical contributors to this project. 
+- If you plan to use an AI agent, discuss this with the maintainers first
+- AI agents should identify themselves as AI  
+- AI agents that generate low-value or disruptive contributions may be restricted or blocked  
+
 ## Release Process
 
 New releases are created manually by a maintainer from the `main` branch. There are no automatic releases triggered by merged pull requests.


### PR DESCRIPTION
Adds a new **AI‑Assisted Contributions** section to `CONTRIBUTING.md`, providing guidance on the responsible use of AI tools.

### Key points  
- Contributors remain responsible and must understand their code  
- Disclosure of significant AI usage (e.g. `Assisted-by:`)  
- Contributions must meet existing quality standards (tests, docs, style)  
- Preference for small, well-scoped PRs (bulk AI PRs may be rejected)  
- Guidance on security, licensing, and AI agents  

### Motivation  
AI-assisted development is becoming more common. This addition helps ensure contributions remain clear, maintainable, and easy to review.

### Impact  
No functional changes,  improves contributor guidance and consistency.